### PR TITLE
fix out of bounds read

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -90,7 +90,7 @@ function contourFinder (imageData) {
   const seen = []
   let skipping = false
 
-  for (var i = 0; i < imageData.data.length; i++) {
+  for (var i = 0; i < imageData.data.length/4; i++) {
 
     if(imageData.data[i * 4] > 128) {
       if(seen[i] || skipping) {


### PR DESCRIPTION
since we access `imageData.data[i * 4]` we only need to loop `imageData.data.length/4`. prevents out of bounds access to `imageData.data`.